### PR TITLE
amd-lcd-lib: Append extern C around the library header file

### DIFF
--- a/include/lcdlib/lcdlib_common.h
+++ b/include/lcdlib/lcdlib_common.h
@@ -1,6 +1,11 @@
 
+#ifdef __cplusplus
+ extern "C" {
+#endif
 #ifndef INCLUDE_LCDLIB_COMMON_H_
 #define INCLUDE_LCDLIB_COMMON_H_
+
+
 
 #define FILEPATHSIZE 64 
 /*  i2c device addr */
@@ -41,3 +46,6 @@ int lcdlib_close_dev(void);
 int lcdlib_write_string(LCD_msgType_t msgType, unsigned char *buffer, int str_len);
 
 #endif  // INCLUDE_LCDLIB_COMMON_H_
+#ifdef __cplusplus
+}
+#endif

--- a/src/lcdlib/lcdlib_common.c
+++ b/src/lcdlib/lcdlib_common.c
@@ -1,3 +1,4 @@
+#include <lcdlib/lcdlib_common.h>
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -5,7 +6,6 @@
 #include <linux/i2c.h>
 #include <linux/i2c-dev.h>
 #include <i2c/smbus.h>
-#include <lcdlib/lcdlib_common.h>
 
 static int fd = -1;
 


### PR DESCRIPTION
Appends extern "C" around the library header file to resolve linker
issues.

Signed-off-by: Supreeth Venkatesh <supreeth.venkatesh@amd.com>