### PR TITLE
amd-lcd-lib: Modify APIs so it can be used by phosphor apps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,11 +84,11 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 set(LCDLIB_SRC_LIST ${LCDLIB_SRC_LIST} "${SRC_DIR}/lcdlib_common.c")
 
 
-set(LCD_TOOL "lcdlib_tool")
+#set(LCD_TOOL "lcdlib_tool")
 
-add_executable(${LCD_TOOL} "example/lcdlib_tool.c")
+#add_executable(${LCD_TOOL} "example/lcdlib_tool.c")
 
-target_link_libraries(${LCD_TOOL} ${LCDLIB_TARGET})
+#target_link_libraries(${LCD_TOOL} ${LCDLIB_TARGET})
 
 add_library(${LCDLIB_TARGET} SHARED ${LCDLIB_SRC_LIST} ${LCD_INC_LIST})
 target_link_libraries(${LCDLIB_TARGET} pthread rt m i2c)

--- a/include/lcdlib/lcdlib_common.h
+++ b/include/lcdlib/lcdlib_common.h
@@ -1,14 +1,12 @@
-
 #ifdef __cplusplus
  extern "C" {
 #endif
 #ifndef INCLUDE_LCDLIB_COMMON_H_
 #define INCLUDE_LCDLIB_COMMON_H_
 
-
-
 #define FILEPATHSIZE 64 
 /*  i2c device addr */
+#define LCD_I2C_BUS     1       // LCD virtual i2c bus
 #define LCD_MUX_ADDR    0x70    // 0x70 is 7-bit MUX address 
 #define LCD_DEV_ADDR    0x28    // 0x28 is 7-bit LCD DEV address
 
@@ -33,17 +31,17 @@ typedef enum
 {
 	POST_CODE = 1,
 	BMC_IPADDR,
-	FW_VER,
-	HOST_NAME
+	BMC_VER,
+	BIOS_VER
 }LCD_msgType_t;
 
-static int  lcdlib_clearScreen(void);
 static int  lcdlib_setCursor(int line, int column);
 static int  lcdlib_setCursorHome(void);
 
-int lcdlib_open_dev(int i2c_channel);
+int lcdlib_open_dev(void);
 int lcdlib_close_dev(void);
 int lcdlib_write_string(LCD_msgType_t msgType, unsigned char *buffer, int str_len);
+int lcdlib_clearScreen(void);
 
 #endif  // INCLUDE_LCDLIB_COMMON_H_
 #ifdef __cplusplus


### PR DESCRIPTION
Modified amd-lcd-lib src code to be used by OpenBMC phosphor services.

Signed-off-by: Mohsen Dolaty <mohsen.dolaty@amd.com>
Signed-off-by: Vinu Vaghasia <vinu.vaghasia@amd.com>